### PR TITLE
Expose Tesla navigation intent

### DIFF
--- a/src/StephanGroen/Tesla/Tesla.php
+++ b/src/StephanGroen/Tesla/Tesla.php
@@ -176,6 +176,19 @@ class Tesla
         return $this->sendRequest('/command/trunk_open?which_trunk=rear', [], 'POST')['response'];
     }
 
+    public function setNavigation($location) : array
+    {
+        $params = [
+            'type' => 'share_ext_content_raw',
+            'value' => [
+                'android.intent.extra.TEXT' => $location
+            ],
+            'locale' => 'en-US',
+            'timestamp_ms' => time(),
+        ];
+        return $this->sendRequest('/command/navigation_request', $params, 'POST')['response'];
+    }
+
     public function getAccessToken(string $username, string $password)
     {
         $ch = curl_init();


### PR DESCRIPTION
This request sends a notification to the API with a location in the querystring `to`. A free form string that simulates a user typing into the navigation search in the vehicle. 

Discovered while working with the Ruby Gem and finding [these updates](https://github.com/timdorr/tesla-api/issues/82). The `en-US` locale is obviously US centric, but wanted to throw it up for discussion. I don't know of the related impact in navigation searches yet.