### PR TITLE
Update vehicle_data endpoint

### DIFF
--- a/src/StephanGroen/Tesla/Tesla.php
+++ b/src/StephanGroen/Tesla/Tesla.php
@@ -21,7 +21,7 @@ class Tesla
 
     public function allData() : array
     {
-        return $this->sendRequest('/data')['response'];
+        return $this->sendRequest('/vehicle_data')['response'];
     }
 
     public function vehicles()


### PR DESCRIPTION
Follow up from PR #8 Updated legacy endpoint for /data. Based on https://tesla-api.timdorr.com/vehicle/state/data.

This is the same rollup of all the data_request endpoints.